### PR TITLE
Fix shell command in reg file

### DIFF
--- a/Peep/Peep.reg
+++ b/Peep/Peep.reg
@@ -1,10 +1,10 @@
 Windows Registry Editor Version 5.00
 
 [HKEY_CLASSES_ROOT\SystemFileAssociations\.jpg\Shell\Peep\Command]
-@="E:\\Dev\\Peep\\Peep\\bin\\Release\\peep.exe %1"
+@="C:\\Dev\\Peep\\Peep\\bin\\Release\\peep.exe \"%1\""
 
 [HKEY_CLASSES_ROOT\SystemFileAssociations\.png\Shell\Peep\Command]
-@="E:\\Dev\\Peep\\Peep\\bin\\Release\\peep.exe %1"
+@="C:\\Dev\\Peep\\Peep\\bin\\Release\\peep.exe \"%1\""
 
 [HKEY_CLASSES_ROOT\SystemFileAssociations\.gif\Shell\Peep\Command]
-@="E:\\Dev\\Peep\\Peep\\bin\\Release\\peep.exe %1"
+@="C:\\Dev\\Peep\\Peep\\bin\\Release\\peep.exe \"%1\""


### PR DESCRIPTION
This change fixes the shell command so that the filename is contained in quotes.  Without this fix, you can't open files with spaces in the path.